### PR TITLE
Fix i18n plugin is optional

### DIFF
--- a/server/utils/validateQuery.js
+++ b/server/utils/validateQuery.js
@@ -1,11 +1,15 @@
 const { ValidationError } = require("@strapi/utils/lib/errors");
 
 const validateQuery = async (contentType, locale) => {
+  if (!locale) {
+    return;
+  }
+  
   const isLocalizedContentType = await strapi.plugins.i18n.services[
     "content-types"
   ].isLocalizedContentType(contentType.model);
 
-  if (locale && !isLocalizedContentType) {
+  if (!isLocalizedContentType) {
     throw new ValidationError(
       `A query for the locale: '${locale}' was found, however model: '${contentType.model.modelName}' is not a localized content type. Enable localization if you want to query or localized entries.`
     );


### PR DESCRIPTION
Since the plugin `@strapi/plugin-i18n` is an optional package that is not required by Strapi website (as mine) so it will cause an error like this even if `locale` parameter is not passed

```
strapi-api       | [2022-06-01 04:27:35.125] error: Cannot read properties of undefined (reading 'services')
strapi-api       | TypeError: Cannot read properties of undefined (reading 'services')
strapi-api       |     at validateQuery (/app/node_modules/strapi-plugin-fuzzy-search/server/utils/validateQuery.js:4:60)
strapi-api       |     at /app/node_modules/strapi-plugin-fuzzy-search/server/services/fuzzySearchService.js:14:15
strapi-api       |     at Array.map (<anonymous>)
strapi-api       |     at Object.getResults (/app/node_modules/strapi-plugin-fuzzy-search/server/services/fuzzySearchService.js:13:20)
strapi-api       |     at Object.search (/app/node_modules/strapi-plugin-fuzzy-search/server/controllers/search-controller.js:14:7)
strapi-api       |     at dispatch (/app/node_modules/koa-compose/index.js:42:32)
strapi-api       |     at returnBodyMiddleware (/app/node_modules/@strapi/strapi/lib/services/server/compose-endpoint.js:52:24)
```

This PR to fix this error.