### PR TITLE
feat(engines): support for node 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "semantic-release": "^22.0.5"
       },
       "engines": {
-        "node": ">=14.x.x <=18.x.x",
+        "node": ">=18.x.x <=20.x.x",
         "npm": ">=6.0.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@wfproductions (https://github.com/wfproductions)"
   ],
   "engines": {
-    "node": ">=14.x.x <=18.x.x",
+    "node": ">=18.x.x <=20.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT",


### PR DESCRIPTION
Strapi is [phasing out](https://github.com/strapi/strapi/releases/tag/v4.14.4) Node.js version 16 support, prompting the need to upgrade to Node.js version 20 for alignment with [Strapi requirements](https://github.com/strapi/strapi/blob/main/package.json#L137).