### PR TITLE
feat: add status filtering to search queries

### DIFF
--- a/server/src/config/query.schema.ts
+++ b/server/src/config/query.schema.ts
@@ -29,4 +29,5 @@ export type SearchQuery = Omit<QuerySchema, 'filters'> & {
   populate?: Record<string, PopulationSchema>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   filters?: QuerySchema['filters'] & Record<string, any>;
+  status?: 'published' | 'draft';
 };

--- a/server/src/controllers/search-controller.ts
+++ b/server/src/controllers/search-controller.ts
@@ -16,6 +16,7 @@ export default () => ({
       filters: filtersQuery,
       locale,
       populate,
+      status: statusQuery,
     } = ctx.query;
     const { auth } = ctx.state;
 
@@ -57,6 +58,7 @@ export default () => ({
             populate: populate?.[contentType.info.pluralName],
             locale:
               filtersQuery?.[contentType.info.pluralName]?.locale || locale,
+            status: statusQuery?.[contentType.info.pluralName] || "published",
           }),
       ),
     );

--- a/server/src/services/fuzzySearch-service.ts
+++ b/server/src/services/fuzzySearch-service.ts
@@ -156,20 +156,23 @@ export default async function getResult({
   filters,
   populate,
   locale,
+  status,
 }: {
   contentType: ContentType;
   query: string;
   filters?: WhereQuery;
   populate?: string;
   locale?: string;
+  status?: 'published' | 'draft';
 }): Promise<Result> {
   const buildFilteredEntries = async () => {
     await validateQuery(contentType, locale);
 
-    return (await strapi.entityService.findMany(contentType.uid, {
+    return (await strapi.documents(contentType.uid).findMany({
       ...(filters && { filters }),
       ...(locale && { locale }),
       ...(populate && { populate }),
+      status: status ?? 'published',
     })) as unknown as Entry[];
   };
 


### PR DESCRIPTION
- Updated search-controller to include status in query parameters.
- Enhanced GraphQL types to accept status as an argument for search queries.
- Modified fuzzySearch service to handle status filtering in document retrieval.